### PR TITLE
Adding section on how to define a report in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,46 @@ This repo both documents and contains the code for running reports. The "report"
 
 It is our intention that this repository serve as the central hub for all reporting documentation. If a report exists, it should have a directory and a README.md file, even if it only contains notes or TODOs. In fact, putting notes and TODOs in this file is totally fine.
 
-# Getting started
+# Contributing to this project
+There are several ways to contribute. All are welcome.
+
+* You can create a new report
+* You can run an existing report
+* You can create an issue or comment on one
+
+See the section below for the steps for creating a report. To run an existing report see the documentation for existing reports in the wiki.
+
+Creating an issue is the easiest way to contribute. Have an idea for a report? Create an issue for it first, describing what you'd like to do.
+
+# What is a report?
+A report consists of data that helps you in your work. It may come from FOLIO or it may come from other systems. After a report is "run" it may consist of columns and rows of data. But a report, as we define it, also refers to the _documentation for how to generate the report_. These docs will allow others, and maybe even your future self, to run and perhaps contribute to the report's development.
+
+# Creating a report
+All new reports should have an issue and a wiki page. All existing reports will have at least a wiki page.
+
+1. Check the [wiki](/wiki) to see to see if your report exists. If it does, follow the documentation there.
+2. If nothing in the wiki exists yet, [create an issue](/issues) for your report. Without an issue it is likely your report won't be seen by others or get worked on.
+3. Create a wiki page for your report. Congratulations, your report now exists! Link to the issue you created on the wiki page for the time being. Say something like "this is work in progress".
+4. Consider tagging other interested parties in your issue. Issues are great places to collaborate and track progress.
+5. Describe the goals of your report. This can be as simple as a few sentences or something more involved -- whatever makes sense. This can be done on the wiki page or in the issue if you're just getting started.
+6. Figure out the [data sources](/wiki/report-data-sources) for your report. There are many ways to get library data, from running a query inside of FOLIO, to creating a SQL query. Document your progress in the wiki page or your issue, whatever seems most appropriate.
+7. Ask for help! If at any point in the process, you're feeling stuck, reach out to the reporting pod on Teams. We'll get you going in the right direction!
+
+## Issue or wiki?
+Issues are good for collaboration. The wiki page is more permanent. Issues ultimately should be closed when the work is complete.
+
+# Current reports
+The [wiki](/wiki) is the central location for all documentation of current reports. Check this first to see if your report or something like it already exists or is underway.
+
+# Working with github and git
+Github and git are central to our reporting work. If you need to create or collaborate on a report that has source code associated with it, it is highly recommended that you install and use git on your local machine.
+
+## Installing git
 Install git following the instructions [here](https://github.com/git-guides/install-git).
 
-Clone the repo, make a branch for your work, add some stuff, and push. Here's how.
+Clone this repo, make a branch for your work, add some stuff, and push. Here's how.
 
-```shell
+```sh
 # Clone this repo.
 git clone https://github.com/culibraries/library-reporting.git
 cd library-reporting
@@ -64,6 +98,3 @@ Squashing is almost always good at this stage, because it combines all of your c
 On your local machine, remember to checkout main by doing `checkout main` and then pull your (and other's changes) by doing `git pull`.
 
 If you haven't done a pull request before (don't worry it's easy) you can always ask someone who has to show you the ropes.
-
-# Current reports
-* **[Example report name](example-report/README.md)** - An example report with a link to it's readme file in the report's name

--- a/README.md
+++ b/README.md
@@ -1,37 +1,43 @@
 # Overview
 This CU Libraries repository for all things reporting, including but not limited to creating reports from FOLIO data.
 
-This repo both documents and contains the code for running reports. The "report" is the basic building block. Each report has its own directory. At minimum, a given report's directory will contain a README.md file. This is the _only_ requirement, however most report directories will contain other items&mdash;perhaps an sql file for example.
-
-It is our intention that this repository serve as the central hub for all reporting documentation. If a report exists, it should have a directory and a README.md file, even if it only contains notes or TODOs. In fact, putting notes and TODOs in this file is totally fine.
+It is our intention that this repository serve as the central hub for all things relevant to reporting (docs, source code and issues). If a report exists, it will have a [wiki page](/wiki) and an entry in the current reports section of the wiki home, even if it only contains notes or TODOs. In fact, putting notes and TODOs in this file is totally fine.
 
 # Contributing to this project
 There are several ways to contribute. All are welcome.
 
 * You can create a new report
-* You can run an existing report
-* You can create an issue or comment on one
+* You can run an [existing report](/wiki)
+* You can [create an issue](/issues) or comment on one
 
-See the section below for the steps for creating a report. To run an existing report see the documentation for existing reports in the wiki.
+See the section below for the steps for running a report or creating a new report.
 
-Creating an issue is the easiest way to contribute. Have an idea for a report? Create an issue for it first, describing what you'd like to do.
+Creating an issue is the easiest way to contribute. Have an idea for a report? Follow the steps below for how to get things going.
 
 # What is a report?
 A report consists of data that helps you in your work. It may come from FOLIO or it may come from other systems. After a report is "run" it may consist of columns and rows of data. But a report, as we define it, also refers to the _documentation for how to generate the report_. These docs will allow others, and maybe even your future self, to run and perhaps contribute to the report's development.
 
-# Creating a report
-All new reports should have an issue and a wiki page. All existing reports will have at least a wiki page.
+# Running or creating a report
+All new reports should have an issue and a wiki page. All existing reports will have at least a wiki page. Reports that have source code may have both a wiki page and a readme.
 
-1. Check the [wiki](/wiki) to see to see if your report exists. If it does, follow the documentation there.
-2. If nothing in the wiki exists yet, [create an issue](/issues) for your report. Without an issue it is likely your report won't be seen by others or get worked on.
-3. Create a wiki page for your report. Congratulations, your report now exists! Link to the issue you created on the wiki page for the time being. Say something like "this is work in progress".
-4. Consider tagging other interested parties in your issue. Issues are great places to collaborate and track progress.
-5. Describe the goals of your report. This can be as simple as a few sentences or something more involved -- whatever makes sense. This can be done on the wiki page or in the issue if you're just getting started.
-6. Figure out the [data sources](/wiki/report-data-sources) for your report. There are many ways to get library data, from running a query inside of FOLIO, to creating a SQL query. Document your progress in the wiki page or your issue, whatever seems most appropriate.
-7. Ask for help! If at any point in the process, you're feeling stuck, reach out to the reporting pod on Teams. We'll get you going in the right direction!
+To run a report:
+
+Check the [wiki](/wiki) to see to see if your report exists. If it does, follow the documentation there on how to run it.
+
+If the report doesn't yet exist, you'll need to create one. Here's how to do that:
+1. [Create an issue](/issues) for your report. Without an issue it is likely your report won't be seen by others or get worked on. Consider tagging other interested parties in your issue. Issues are great places to collaborate.
+1. Create a [wiki](/wiki) page for your report. Congratulations, your report now exists! Link to the issue you created on the wiki page for the time being. Link to the wiki page from the issue. Feel free to use the wiki page to document your progress or keep notes in case someone else needs to take things up where you left off.
+1. Create an entry for your report in the current reports section of the [wiki home page](/wiki). Set the status to in progress. Give your report a priority. See the [report priority guide](/wiki/report-priority-guide).
+1. Create a one or two sentence description for your report. Put this both on the wiki page for your report and in the issue. Consulting the [report documentation guide](/wiki/report-documentation-guide) may be helpful at this point.
+1. Figure out the [data sources](/wiki/report-data-sources) for your report. There are many ways to get library data, from running a query inside of FOLIO, to creating a SQL query. Document your progress in the wiki page or your issue, whatever seems most appropriate.
+1. Ask for help! If at any point in the process, you're feeling stuck, reach out to the reporting pod on Teams. We'll get you going in the right direction!
+1. Once you've figured out your [data sources](/wiki/report-data-sources) and have run your report, finish up the wiki page about your report, consulting the [report documentation guide](/wiki/report-documentation-guide).
+1. Finish up the entry for your report in the current reports section of the [wiki home page](/wiki). Set the status to done.
+1. If your report has source code associated with it, open a pull request so that others can take a look at it and it can get merged to the main branch. See below for more on pull requests.
+1. You can now close the issue [issue](/issues) associated with your report.
 
 ## Issue or wiki?
-Issues are good for collaboration. The wiki page is more permanent. Issues ultimately should be closed when the work is complete.
+Issues are good for collaboration. The wiki page is more permanent. Issues ultimately should be closed when the work is complete. Wiki pages hang around forever.
 
 # Current reports
 The [wiki](/wiki) is the central location for all documentation of current reports. Check this first to see if your report or something like it already exists or is underway.
@@ -68,7 +74,7 @@ Afterwords you can continue to push using the simpler `git push`. It will rememb
 
 The [git guides](https://github.com/git-guides) are super helpful for more documentation if that's your thing.
 
-## Authenticating to github
+## Authenticating to github from the command line
 You don't need to be logged into github to `clone` and `pull`. But you do need to be logged in to `push`. Creating a personal access token is the way to log in. Once you have done so, you use it like a password. Also make sure to protect it like one too!
 
 To create a personal access token:

--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ See the section below for the steps for running a report or creating a new repor
 
 Creating an issue is the easiest way to contribute. Have an idea for a report? Follow the steps below for how to get things going.
 
+# Getting access to this repository
+Just ping the pod on Teams with your github username and someone will add you to the repository.
+
 # What is a report?
 A report consists of data that helps you in your work. It may come from FOLIO or it may come from other systems. After a report is "run" it may consist of columns and rows of data. But a report, as we define it, also refers to the _documentation for how to generate the report_. These docs will allow others, and maybe even your future self, to run and perhaps contribute to the report's development.
 


### PR DESCRIPTION
Added a section on creating a report which spells out the role of the wiki and issues. There's an issue for this PR here: #6. 

There are a few ideas here:
* Trying to spell out how anyone can come in and get started with reporting.
* Trying to make it clear how _we_ can do it too (issue #5).
* Trying to encourage collaboration from folks outside the pod.
* I think we should make the wiki be the main documentation hub, and only do readmes for reports that have source code like SQL. 

I think this will reduce the need to fiddle with git on command line. In other words, a report which is purely documentation-oriented won't require any work on the command line. But we can still take advantage of having a github ticket for it (if it is new) and documenting it in the wiki.